### PR TITLE
attach driver unload routine properly

### DIFF
--- a/kernel_helloworld/main.cpp
+++ b/kernel_helloworld/main.cpp
@@ -10,7 +10,7 @@ VOID driverUnload(PDRIVER_OBJECT _driverObject) {
 }
 
 extern "C" NTSTATUS DriverEntry(PDRIVER_OBJECT _driverObject, PUNICODE_STRING _registryPath) {
-    UNREFERENCED_PARAMETER(_driverObject);
+    _driverObject->DriverUnload = driverUnload;
     UNREFERENCED_PARAMETER(_registryPath);
     DbgPrint("[WDKTest] Hello World\n");
     return 0;


### PR DESCRIPTION
Hi! Thanks for the good repository.

I found it weird that driverUnload function exists but dangling.
I'm sorry if this is intentional but i assume it'd be friendly to connect it to driverObject.

You can close this if it's all for simplicity and no need:)